### PR TITLE
feat: PoC of checking DataExtraction Queue stability via UiPath API

### DIFF
--- a/folder.go
+++ b/folder.go
@@ -38,12 +38,14 @@ type FolderList struct {
 // List fetches a list of folders that can be filtered using query parameters
 func (f *FolderHandler) List(filters map[string]string) ([]Folder, int, error) {
 	var folderList FolderList
+	var headers = map[string]string{}
 
 	url := fmt.Sprintf("%s%s", f.Client.BaseURL, FolderEndpoint)
 
-	resp, err := f.Client.SendWithAuthorization("GET", url, nil, nil, filters)
+	resp, err := f.Client.SendWithAuthorization("GET", url, nil, headers, filters)
+
 	if err != nil {
-		return folderList.Value, folderList.Count, err
+		return folderList.Value, 0, err
 	}
 
 	err = json.Unmarshal(resp, &folderList)

--- a/folder.go
+++ b/folder.go
@@ -1,0 +1,52 @@
+package uipath
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	FolderEndpoint = "Folders"
+)
+
+// FolderHandler struct defines what the folder handler looks like
+type FolderHandler struct {
+	Client *Client
+}
+
+// Folder struct defines what the folder model looks like
+type Folder struct {
+	IsPersonal         bool   `json:"IsPersonal,omitempty"`
+	ID                 uint   `json:"Id"`
+	ParentId           int64  `json:"ParentId,omitempty"`
+	Key                string `json:"Key"`
+	DisplayName        string `json:"DisplayName,omitempty"`
+	FullyQualifiedName string `json:"FullyQualifiedName"`
+	Description        string `json:"Description,omitempty"`
+	ProvisionType      string `json:"ProvisionType,omitempty"`
+	PermissionModel    string `json:"PermissionModel,omitempty"`
+	ParentKey          string `json:"ParentKey,omitempty"`
+	FeedType           string `json:"FeedType,omitempty"`
+}
+
+// FolderList struct defines what response of the list endpoint looks like
+type FolderList struct {
+	Count int      `json:"@odata.count"`
+	Value []Folder `json:"value"`
+}
+
+// List fetches a list of folders that can be filtered using query parameters
+func (f *FolderHandler) List(filters map[string]string) ([]Folder, int, error) {
+	var folderList FolderList
+
+	url := fmt.Sprintf("%s%s", f.Client.BaseURL, FolderEndpoint)
+
+	resp, err := f.Client.SendWithAuthorization("GET", url, nil, nil, filters)
+	if err != nil {
+		return folderList.Value, folderList.Count, err
+	}
+
+	err = json.Unmarshal(resp, &folderList)
+
+	return folderList.Value, folderList.Count, err
+}

--- a/queue_definition.go
+++ b/queue_definition.go
@@ -1,0 +1,74 @@
+package uipath
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+const (
+	QueueDefinitionEndpoint = "QueueDefinitions"
+)
+
+// QueueDefinitionHandler struct defines what the queuedefinition handler looks like
+type QueueDefinitionHandler struct {
+	Client            *Client
+	QueueDefinitionId uint
+	FolderID          uint
+}
+
+// QueueDefinition struct defines what the queuedefinition model looks like
+type QueueDefinition struct {
+	AcceptAutomaticallyRetry           bool      `json:"AcceptAutomaticallyRetry,omitempty"`
+	EnforceUniqueReference             bool      `json:"EnforceUniqueReference,omitempty"`
+	Encrypted                          bool      `json:"Encrypted,omitempty"`
+	IsProcessInCurrentFolder           bool      `json:"IsProcessInCurrentFolder,omitempty"`
+	ID                                 uint      `json:"Id"`
+	MaxNumberOfRetries                 int32     `json:"MaxNumberOfRetries,omitempty"`
+	SlaInMinutes                       int32     `json:"SlaInMinutes,omitempty"`
+	RiskSlaInMinutes                   int32     `json:"RiskSlaInMinutes,omitempty"`
+	FoldersCount                       int32     `json:"FoldersCount,omitempty"`
+	OrganizationUnitId                 int64     `json:"OrganizationUnitId,omitempty"`
+	ProcessScheduleId                  int64     `json:"ProcessScheduleId,omitempty"`
+	ReleaseId                          int64     `json:"ReleaseId,omitempty"`
+	CreationTime                       time.Time `json:"CreationTime,omitempty"`
+	Key                                string    `json:"Key"`
+	Description                        string    `json:"Description,omitempty"`
+	Name                               string    `json:"Name"`
+	SpecificDataJsonSchema             string    `json:"SpecificDataJsonSchema,omitempty"`
+	OutputDataJsonSchema               string    `json:"OutputDataJsonSchema,omitempty"`
+	AnalyticsDataJsonSchema            string    `json:"AnalyticsDataJsonSchema,omitempty"`
+	OrganizationUnitFullyQualifiedName string    `json:"OrganizationUnitFullyQualifiedName,omitempty"`
+	Tags                               []string  `json:"Tag,omitempty"`
+}
+
+// QueueDefinitionList struct defines what response of the list endpoint looks like
+type QueueDefinitionList struct {
+	Count int               `json:"@odata.count"`
+	Value []QueueDefinition `json:"value"`
+}
+
+// List fetches a list of queuedefinitions that can be filtered using query parameters
+func (q *QueueDefinitionHandler) List(filters map[string]string) ([]QueueDefinition, int, error) {
+	var queuedefinitionList QueueDefinitionList
+
+	url := fmt.Sprintf("%s%s", q.Client.BaseURL, QueueDefinitionEndpoint)
+
+	resp, err := q.Client.SendWithAuthorization("GET", url, nil, q.buildHeaders(), filters)
+	if err != nil {
+		return queuedefinitionList.Value, queuedefinitionList.Count, err
+	}
+
+	err = json.Unmarshal(resp, &queuedefinitionList)
+
+	return queuedefinitionList.Value, queuedefinitionList.Count, err
+}
+
+func (q *QueueDefinitionHandler) buildHeaders() map[string]string {
+	var headers = map[string]string{}
+
+	headers[HeaderOrganizationUnitId] = strconv.Itoa(int(q.FolderID))
+
+	return headers
+}

--- a/queue_item.go
+++ b/queue_item.go
@@ -12,7 +12,7 @@ const (
 	PriorityNormal = "Normal"
 	PriorityHigh   = "High"
 
-	QueueItemEndpoint    = "QueueItem"
+	QueueItemEndpoint    = "QueueItems"
 	QueueAddItemEndpoint = "Queues/UiPathODataSvc.AddQueueItem"
 )
 


### PR DESCRIPTION
## Description

In this PoC, tring to find out the way to check if the UiPath Process is stable or not using `QueueDefinitions and` `Folderrs` endpoints.

## DataFlow
(1) GET Folder IDs under Portal dir
`%2Fodata%2Ffolders%3F%24Filter%3Dcontains(FullyQualifiedName%2C%20'Portals%2F')`
(2) GET Data Extraction Queue for each Portal FOlder
`odata%2FQueueDefinitions%3F%24filter%3Dcontains(Name%2C%20'DataExtraction')`
(3) GET Failed Items of Data Extraction Queue which are failed in last X minutes 
`%2Fodata%2FQueueItems%3F%24select%3DQueueDefinitionId%2C%20Id%2C%20SpecificContent%2C%20StartProcessing%2C%20Status%26%24filter%3DQueueDefinitionId%20eq%2051386%26%24top%3D1`

## Payload sample
```
{
 "OrganizationUnitFullyQualifiedName": "Portals/SUUMO-JDS",
 "ProcessingException": {
     "Reason": "The browser failed to launch.",
     "Details": "Screenshot: Exceptions_Screenshots\\ExceptionScreenshot_221118.021839.png",
     "Type": "ApplicationException",
     "AssociatedImageFilePath": null,
     "CreationTime": "2022-11-18T02:18:40.07Z"
 },
 "SpecificContent": {
    "AccountID": 2,
    "CredentialName": "dgm-2-84-credential",
    "LastSubmittedAt": "2022-11-12 02:41:16",
    "LastSubmittedProviderIdentifier": "0083945896",
    "PortalID": 84,
    "SubmittedAt": "2022-11-12 11:41:16"
 },
}
```

## Reference
https://comvex.myjetbrains.com/youtrack/issue/DGM2-10656/Research-if-we-can-monitor-UIPath-Queue

## AC
* [x] Check if we can fetch failed Queue Items of Specific Queue Definition in Specific Folder.